### PR TITLE
Add manual notification send feature

### DIFF
--- a/src/domain_check/main.py
+++ b/src/domain_check/main.py
@@ -918,10 +918,24 @@ async def send_notification_email(request: SendNotificationRequest):
         result = await notification_handler.send_immediate_notification(request.email, domains)
 
         if result.get("sent"):
-            return {"status": "success", "message": "Expiry report sent via email", "domains": domains}
+            status = "success"
+            message = "Expiry report sent via email"
         else:
-            error_msg = result.get("error", "Failed to send email")
-            return JSONResponse(content={"status": "error", "message": error_msg}, status_code=500)
+            status = "error"
+            message = result.get("error", "Failed to send email")
+
+        response_data = {
+            "status": status,
+            "message": message,
+            "domains": domains,
+            "expiring_domains": result.get("expiring_domains", []),
+            "expiring_certs": result.get("expiring_certs", [])
+        }
+
+        if status == "success":
+            return response_data
+        else:
+            return JSONResponse(content=response_data, status_code=500)
 
     except Exception as e:
         logging.error(f"Error sending notification email: {e}")

--- a/src/domain_check/main.py
+++ b/src/domain_check/main.py
@@ -98,6 +98,8 @@ class SubscriptionResponse(BaseModel):
     status: str
     message: str
     domains: Optional[List[str]] = None
+    expiring_domains: Optional[List[Dict]] = None
+    expiring_certs : Optional[List[Dict]] = None
     
 class OTPVerificationRequest(BaseModel):
     email: EmailStr
@@ -934,6 +936,7 @@ async def send_notification_email(request: SendNotificationRequest):
             "expiring_domains": result.get("expiring_domains", []),
             "expiring_certs": result.get("expiring_certs", [])
         }
+        print("Response data:", response_data)
 
         if status == "success":
             return response_data

--- a/src/domain_check/main.py
+++ b/src/domain_check/main.py
@@ -87,6 +87,10 @@ class DomainUnregistrationRequest(BaseModel):
     domains: Optional[List[str]] = None
     otp: str  # Include OTP directly in the request for verification
 
+class SendNotificationRequest(BaseModel):
+    email: EmailStr
+    otp: str
+
 class SubscriptionResponse(BaseModel):
     status: str
     message: str
@@ -882,6 +886,46 @@ async def get_all_subscriptions():
     """
     subscriptions = notification_handler.get_all_subscriptions()
     return {"subscriptions": subscriptions, "count": len(subscriptions)}
+
+@app.post("/api/notifications/send", response_model=SubscriptionResponse)
+async def send_notification_email(request: SendNotificationRequest):
+    """Send an immediate expiry report for all domains registered by the user."""
+    try:
+        if not request.otp:
+            return JSONResponse(content={
+                "status": "error",
+                "message": "Verification code required. Please provide a verification code.",
+                "require_otp": True
+            }, status_code=403)
+
+        success, message = otp_handler.verify_otp(request.email, request.otp)
+        logging.info(f"OTP verification for send: {success}, message: {message}")
+
+        if not success:
+            return JSONResponse(content={
+                "status": "error",
+                "message": f"Verification failed: {message}",
+                "require_otp": True
+            }, status_code=403)
+
+        domains = notification_handler.get_domains(request.email)
+        if not domains:
+            return JSONResponse(content={
+                "status": "error",
+                "message": "No domains registered for this email address"
+            }, status_code=404)
+
+        result = await notification_handler.send_immediate_notification(request.email, domains)
+
+        if result.get("sent"):
+            return {"status": "success", "message": "Expiry report sent via email", "domains": domains}
+        else:
+            error_msg = result.get("error", "Failed to send email")
+            return JSONResponse(content={"status": "error", "message": error_msg}, status_code=500)
+
+    except Exception as e:
+        logging.error(f"Error sending notification email: {e}")
+        return JSONResponse(content={"status": "error", "message": str(e)}, status_code=500)
 
 # Add after the existing API endpoints
 

--- a/src/domain_check/notification_handler.py
+++ b/src/domain_check/notification_handler.py
@@ -308,8 +308,10 @@ class NotificationHandler:
                 expiring_certs=ssl_results,
                 days_threshold=days_threshold
             )
-            
+
             logger.info(f"Immediate notification result: {notification_result}")
+            notification_result["expiring_domains"] = domain_results
+            notification_result["expiring_certs"] = ssl_results
             return notification_result
         except Exception as e:
             logger.error(f"Error sending immediate notification: {e}")

--- a/templates/index.html
+++ b/templates/index.html
@@ -480,16 +480,19 @@
             for (var i = 0; i < tabcontent.length; i++) {
                 tabcontent[i].classList.remove("active");
             }
-            
+
             // Remove active class from all tab buttons
             var tablinks = document.getElementsByClassName("tab-button");
             for (var i = 0; i < tablinks.length; i++) {
                 tablinks[i].classList.remove("active");
             }
-            
+
             // Show the current tab and mark its button as active
             document.getElementById(tabName).classList.add("active");
             evt.currentTarget.classList.add("active");
+
+            // Clear any displayed expiry report when switching tabs
+            clearExpiryReport();
         }
         
         // Notification API functions
@@ -624,6 +627,8 @@
 
         
         function registerDomains() {
+            clearExpiryReport();
+
             const email = document.getElementById('notificationEmail').value;
             const domainsText = document.getElementById('notificationDomains').value;
             let domains = [];
@@ -703,6 +708,8 @@
         }
         
         function getDomains() {
+            clearExpiryReport();
+
             const email = document.getElementById('notificationEmail').value;
             
             if (!email) {
@@ -806,7 +813,9 @@
             });
         }
         
-        function unregisterDomain(email, domain) {
+       function unregisterDomain(email, domain) {
+            clearExpiryReport();
+
             // Store details for pending operation
             pendingOperation = 'unregister';
             pendingEmail = email;
@@ -822,7 +831,9 @@
             }
         }
         
-        function unregisterAllDomains() {
+       function unregisterAllDomains() {
+            clearExpiryReport();
+
             const email = document.getElementById('notificationEmail').value;
             
             if (!email) {
@@ -849,7 +860,9 @@
             }
         }
 
-        function sendNotification() {
+       function sendNotification() {
+            clearExpiryReport();
+
             const email = document.getElementById('notificationEmail').value;
 
             if (!email) {
@@ -927,6 +940,17 @@
             });
             
             document.getElementById('registeredDomains').style.display = 'block';
+        }
+
+        // Clear the inline expiry report and hide the section
+        function clearExpiryReport() {
+            const reportSection = document.getElementById('sendReportResults');
+            const domainTable = document.getElementById('sendReportDomainTable');
+            const certTable = document.getElementById('sendReportCertTable');
+
+            if (domainTable) domainTable.innerHTML = '';
+            if (certTable) certTable.innerHTML = '';
+            if (reportSection) reportSection.style.display = 'none';
         }
 
         function displayExpiryReport(domains, certs) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -351,6 +351,12 @@
                 <div id="domainsList"></div>
                 <button type="button" onclick="unregisterAllDomains()" class="remove-domain">Unregister All Domains</button>
             </div>
+
+            <div id="sendReportResults" class="results" style="display:none;">
+                <h3>Your Expiry Report</h3>
+                <div id="sendReportDomainTable"></div>
+                <div id="sendReportCertTable"></div>
+            </div>
         </div>
 
         <div class="about-section">
@@ -890,6 +896,10 @@
                 } else {
                     showNotificationError(data.message);
                 }
+
+                if (data.expiring_domains || data.expiring_certs) {
+                    displayExpiryReport(data.expiring_domains, data.expiring_certs);
+                }
             })
             .catch(error => {
                 document.getElementById('loadingDialog').style.display = 'none';
@@ -919,6 +929,39 @@
             });
             
             document.getElementById('registeredDomains').style.display = 'block';
+        }
+
+        function displayExpiryReport(domains, certs) {
+            const reportSection = document.getElementById('sendReportResults');
+            const domainTable = document.getElementById('sendReportDomainTable');
+            const certTable = document.getElementById('sendReportCertTable');
+
+            domainTable.innerHTML = '';
+            certTable.innerHTML = '';
+
+            let hasData = false;
+
+            if (domains && domains.length > 0) {
+                let html = '<h4>Domains Expiring Soon</h4><table><tr><th>Domain</th><th>Expiry Date</th><th>Days Left</th><th>Registrar</th></tr>';
+                domains.forEach(d => {
+                    html += `<tr><td>${d.domain}</td><td>${d.expiry_date}</td><td>${d.days_left}</td><td>${d.registrar}</td></tr>`;
+                });
+                html += '</table>';
+                domainTable.innerHTML = html;
+                hasData = true;
+            }
+
+            if (certs && certs.length > 0) {
+                let html = '<h4>SSL Certificates Expiring Soon</h4><table><tr><th>Hostname</th><th>Issuer</th><th>Expiry Date</th><th>Days Left</th></tr>';
+                certs.forEach(c => {
+                    html += `<tr><td>${c.hostname}</td><td>${c.cert_issuer || ''}</td><td>${c.not_after}</td><td>${c.days_to_expire}</td></tr>`;
+                });
+                html += '</table>';
+                certTable.innerHTML = html;
+                hasData = true;
+            }
+
+            reportSection.style.display = hasData ? 'block' : 'none';
         }
         
         function showNotificationSuccess(message) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -341,6 +341,7 @@
             
             <button type="button" onclick="registerDomains()">Register Domains for Notifications</button>
             <button type="button" onclick="getDomains()">View My Registered Domains</button>
+            <button type="button" onclick="sendNotification()">Email My Expiry Report</button>
             
             <div id="notificationSuccess" class="notification-message success"></div>
             <div id="notificationError" class="notification-message error"></div>
@@ -607,6 +608,8 @@
                 performGetDomains(pendingEmail, pendingOTP);
             } else if (pendingOperation === 'unregister') {
                 performUnregistration(pendingEmail, pendingDomains, pendingOTP);
+            } else if (pendingOperation === 'send') {
+                performSendNotification(pendingEmail, pendingOTP);
             } else {
                 document.getElementById('loadingDialog').style.display = 'none';
                 showNotificationError("Unknown operation type");
@@ -838,6 +841,60 @@
                 // Request OTP first
                 requestOTP(email, 'unregister');
             }
+        }
+
+        function sendNotification() {
+            const email = document.getElementById('notificationEmail').value;
+
+            if (!email) {
+                showNotificationError("Please enter your email address");
+                return;
+            }
+
+            pendingOperation = 'send';
+            pendingEmail = email;
+
+            const storedOTP = getStoredOTP(email, 'send');
+            if (storedOTP) {
+                performSendNotification(email, storedOTP.otp);
+            } else {
+                requestOTP(email, 'send');
+            }
+        }
+
+        function performSendNotification(email, otp) {
+            document.getElementById('loadingMessage').textContent = "Sending expiry report...";
+            document.getElementById('loadingDialog').style.display = 'block';
+
+            fetch('/api/notifications/send', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    email: email,
+                    otp: otp
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('loadingDialog').style.display = 'none';
+                if (data.status === 'success') {
+                    showNotificationSuccess(data.message);
+                    pendingOperation = null;
+                    pendingEmail = null;
+                    pendingOTP = null;
+                } else if (data.require_otp) {
+                    showNotificationError(data.message);
+                    showOTPDialog();
+                } else {
+                    showNotificationError(data.message);
+                }
+            })
+            .catch(error => {
+                document.getElementById('loadingDialog').style.display = 'none';
+                showNotificationError("Error: " + error.message);
+            });
         }
         
         function displayDomains(domains, email) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -897,9 +897,7 @@
                     showNotificationError(data.message);
                 }
 
-                if (data.expiring_domains || data.expiring_certs) {
-                    displayExpiryReport(data.expiring_domains, data.expiring_certs);
-                }
+                displayExpiryReport(data.expiring_domains, data.expiring_certs);
             })
             .catch(error => {
                 document.getElementById('loadingDialog').style.display = 'none';
@@ -961,7 +959,11 @@
                 hasData = true;
             }
 
-            reportSection.style.display = hasData ? 'block' : 'none';
+            if (!hasData) {
+                domainTable.innerHTML = '<p>No domains or SSL certificates are expiring soon.</p>';
+            }
+
+            reportSection.style.display = 'block';
         }
         
         function showNotificationSuccess(message) {


### PR DESCRIPTION
## Summary
- add `SendNotificationRequest` model
- add `/api/notifications/send` endpoint to trigger immediate report email
- include new button and JS functions on notification settings screen
- allow OTP verification for 'send' operation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684606614b6c832baab34a92400636f6