### PR TITLE
Replace prints with logging

### DIFF
--- a/src/domain_check/domain_check.py
+++ b/src/domain_check/domain_check.py
@@ -10,7 +10,7 @@ try:
     from dateutil import parser
     import asyncio
 except ImportError:
-    print("Please install the python-whois package: pip install python-whois")
+    logging.error("Please install the python-whois package: pip install python-whois")
     raise
 
 import ssl
@@ -149,7 +149,7 @@ async def check_domain_expiry(domain: str) -> WhoisEntry:
                 tlds_path = os.path.join(
                     os.getcwd(), os.path.dirname(__file__), "data", "public_suffix_list.dat"
                 )
-                print(f"Loading TLDs from {tlds_path}")
+                logging.info(f"Loading TLDs from {tlds_path}")
                 with open(tlds_path, encoding="utf-8") as tlds_fp:
                     suffixes = set(
                         line.encode("utf-8")

--- a/src/domain_check/init_application.py
+++ b/src/domain_check/init_application.py
@@ -135,6 +135,6 @@ def init_application() -> Dict[str, Any]:
 
 # Run initialization if this module is imported
 initialization_result = init_application()
-print("Initialization result:", initialization_result)
+logger.debug("Initialization result: %s", initialization_result)
 # Export for use in other modules
 __all__ = ['init_application', 'load_environment', 'initialization_result']

--- a/src/domain_check/main.py
+++ b/src/domain_check/main.py
@@ -178,7 +178,6 @@ async def scheduled_domain_check():
             json.dump(results, f, indent=2)
         
         logging.info(f"Results saved to {results_file}")
-        print(f"Results saved to {results_file}")
 
         # Track successful completion
         try:
@@ -936,7 +935,7 @@ async def send_notification_email(request: SendNotificationRequest):
             "expiring_domains": result.get("expiring_domains", []),
             "expiring_certs": result.get("expiring_certs", [])
         }
-        print("Response data:", response_data)
+        logging.debug("Response data: %s", response_data)
 
         if status == "success":
             return response_data

--- a/src/domain_check/run_scheduler.py
+++ b/src/domain_check/run_scheduler.py
@@ -52,9 +52,9 @@ def main():
     results = scheduler.run_scheduled_check()
     
     # Print results summary
-    print(f"Check completed at {results['end_time']}")
-    print(f"Duration: {results['duration_seconds']:.2f} seconds")
-    print(f"Notifications sent: {results['notifications_sent']}")
+    logger.info(f"Check completed at {results['end_time']}")
+    logger.info(f"Duration: {results['duration_seconds']:.2f} seconds")
+    logger.info(f"Notifications sent: {results['notifications_sent']}")
     
     # Save results to a JSON file for record-keeping
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -69,7 +69,6 @@ def main():
         json.dump(results, f, indent=2)
     
     logger.info(f"Results saved to {results_file}")
-    print(f"Results saved to {results_file}")
     
     return 0
 

--- a/src/domain_check/ssl_check.py
+++ b/src/domain_check/ssl_check.py
@@ -63,7 +63,7 @@ class SSLChecker:
                 try:
                     # Fetch A records for the domain itself
                     answers = resolver.resolve(domain, record_type)
-                    print("AAA",len(answers))
+                    logging.debug("DNS answers for %s (%s): %d", domain, record_type, len(answers))
                     for rdata in answers:
                         if record_type in ['A', 'AAAA']:
                             # Add the domain itself (if it resolves)
@@ -222,14 +222,14 @@ class SSLChecker:
         try:
             # Get list of subdomains to check
             domains_to_check = set(self.get_subdomains(domain))
-            print(f"Domains to check: {domains_to_check}")
+            logging.debug("Domains to check: %s", domains_to_check)
             domains_to_check.add(domain)  # Add root domain
             
             # Check certificates for each domain/subdomain
             for d in domains_to_check:
-                print("getting the certificate info for ", d)
+                logging.debug("Getting the certificate info for %s", d)
                 r1 = await self.get_certificate_info(d)
-                print(r1)
+                logging.debug("Certificate info: %s", r1)
                 if r1:
                     days_left = r1["days_to_expire"]
                     r1["domain"] = domain


### PR DESCRIPTION
## Summary
- use logging calls instead of print statements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68489d694c0c832bb0f7bf454044eba5